### PR TITLE
Fix deprecation errors when doing make

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://repo.or.cz/git2cl.git
 [submodule "jimtcl"]
 	path = jimtcl
-	url = https://repo.or.cz/jimtcl.git
+	url = https://github.com/msteveb/jimtcl.git
 [submodule "src/jtag/drivers/libjaylink"]
 	path = src/jtag/drivers/libjaylink
 	url = https://repo.or.cz/libjaylink.git

--- a/README.OSX
+++ b/README.OSX
@@ -18,10 +18,7 @@ documentation. Alternatively, install the prerequisites and build
 manually from the sources.
 
 
-With Homebrew you can either run:
-  brew install [--HEAD] openocd (where optional --HEAD asks brew to
-                                 install the current git version)
-    or
+With Homebrew you need to run:
   brew install libtool automake libusb [libusb-compat] [hidapi] [libftdi]
     (to install the needed dependencies and then proceed with the
      manual building procedure)

--- a/src/jtag/drivers/openjtag.c
+++ b/src/jtag/drivers/openjtag.c
@@ -436,7 +436,7 @@ static int openjtag_init_standard(void)
 		return ERROR_JTAG_DEVICE_ERROR;
 	}
 
-	if (ftdi_usb_purge_buffers(&ftdic) < 0) {
+	if (ftdi_tcioflush(&ftdic) < 0) {
 		LOG_ERROR("ftdi_purge_buffers: %s", ftdic.error_str);
 		return ERROR_JTAG_INIT_FAILED;
 	}

--- a/src/jtag/drivers/presto.c
+++ b/src/jtag/drivers/presto.c
@@ -160,7 +160,7 @@ static int presto_open_libftdi(char *req_serial)
 		return ERROR_JTAG_DEVICE_ERROR;
 	}
 
-	if (ftdi_usb_purge_buffers(&presto->ftdic) < 0) {
+	if (ftdi_tcioflush(&presto->ftdic) < 0) {
 		LOG_ERROR("unable to purge PRESTO buffers");
 		return ERROR_JTAG_DEVICE_ERROR;
 	}
@@ -174,7 +174,7 @@ static int presto_open_libftdi(char *req_serial)
 	if (presto_read(&presto_data, 1) != ERROR_OK) {
 		LOG_DEBUG("no response from PRESTO, retrying");
 
-		if (ftdi_usb_purge_buffers(&presto->ftdic) < 0)
+		if (ftdi_tcioflush(&presto->ftdic) < 0)
 			return ERROR_JTAG_DEVICE_ERROR;
 
 		presto_data = 0xD0;


### PR DESCRIPTION
Updates the `ftdi_usb_purge_buffers` with the `ftdi_tcioflush` from the sourceforge openocd repository, which fixes manually building the repo from source.
Also updates the jimtcl link, also taken from the sourceforge openocd repository.